### PR TITLE
Update release workflow to use workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,19 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Install protobuf compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "4.0"
           bundler-cache: true
 
       - name: Update version


### PR DESCRIPTION
## Summary
- Replaces tag-triggered release with `workflow_dispatch`
- Enter version in GitHub Actions UI → workflow updates version.rb, commits, tags, builds gem, pushes to RubyGems, creates GitHub Release
- No more manual version.rb edits + tag dance

## Usage
1. Go to Actions → Release → Run workflow
2. Enter version (e.g. `0.4.0`)
3. Click 'Run workflow'

🤖 Generated with [Claude Code](https://claude.com/claude-code)