### PR TITLE
Fix Cargo.toml: restore newline after magnus dep

### DIFF
--- a/ext/lancelot/Cargo.toml
+++ b/ext/lancelot/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-magnus = "0.8"lance = { version = "3.0", default-features = false }
+magnus = "0.8"
+lance = { version = "3.0", default-features = false }
 lance-index = "3.0"
 lance-linalg = "3.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }


### PR DESCRIPTION
The prior embed-removal commit accidentally joined the magnus line with the next dependency. This restores the line break so Cargo.toml parses.